### PR TITLE
Linux support for bootstrap.sh (Raspberry Pi, Debian)

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,3 +1,12 @@
+[env]
+BAT_THEME = "ansi"
+DISABLE_SPRING = "true"
+DOCKER_SCAN_SUGGEST = "false"
+VTK_DISABLE_ANALYTICS = "true"
+CLAUDE_NOTIFY_SLACK = "false"
+OBJC_DISABLE_INITIALIZE_FORK_SAFETY = "YES"
+GITLEAKS_CONFIG = "{{env.HOME}}/.config/gitleaks/config.toml"
+
 [settings]
 ruby.compile = false
 

--- a/.fzf.zsh
+++ b/.fzf.zsh
@@ -5,7 +5,7 @@ if [[ ! "$PATH" == */opt/homebrew/opt/fzf/bin* ]]; then
 fi
 
 # Auto-completion + key bindings — Homebrew (macOS) or Debian/Ubuntu paths.
-[[ -r /opt/homebrew/opt/fzf/shell/completion.zsh ]]   && source /opt/homebrew/opt/fzf/shell/completion.zsh   2>/dev/null
+[[ -r /opt/homebrew/opt/fzf/shell/completion.zsh ]]   && source /opt/homebrew/opt/fzf/shell/completion.zsh
 [[ -r /opt/homebrew/opt/fzf/shell/key-bindings.zsh ]] && source /opt/homebrew/opt/fzf/shell/key-bindings.zsh
-[[ -r /usr/share/doc/fzf/examples/completion.zsh ]]   && source /usr/share/doc/fzf/examples/completion.zsh   2>/dev/null
+[[ -r /usr/share/doc/fzf/examples/completion.zsh ]]   && source /usr/share/doc/fzf/examples/completion.zsh
 [[ -r /usr/share/doc/fzf/examples/key-bindings.zsh ]] && source /usr/share/doc/fzf/examples/key-bindings.zsh

--- a/.fzf.zsh
+++ b/.fzf.zsh
@@ -4,14 +4,8 @@ if [[ ! "$PATH" == */opt/homebrew/opt/fzf/bin* ]]; then
   export PATH="${PATH:+${PATH}:}/opt/homebrew/opt/fzf/bin"
 fi
 
-# Auto-completion + key bindings — try Homebrew (macOS) then Debian/Ubuntu paths.
-for _fzf_base in \
-  /opt/homebrew/opt/fzf/shell \
-  /usr/share/doc/fzf/examples; do
-  if [[ -r "$_fzf_base/key-bindings.zsh" ]]; then
-    [[ $- == *i* ]] && source "$_fzf_base/completion.zsh" 2>/dev/null
-    source "$_fzf_base/key-bindings.zsh"
-    break
-  fi
-done
-unset _fzf_base
+# Auto-completion + key bindings — Homebrew (macOS) or Debian/Ubuntu paths.
+[[ -r /opt/homebrew/opt/fzf/shell/completion.zsh ]]   && source /opt/homebrew/opt/fzf/shell/completion.zsh   2>/dev/null
+[[ -r /opt/homebrew/opt/fzf/shell/key-bindings.zsh ]] && source /opt/homebrew/opt/fzf/shell/key-bindings.zsh
+[[ -r /usr/share/doc/fzf/examples/completion.zsh ]]   && source /usr/share/doc/fzf/examples/completion.zsh   2>/dev/null
+[[ -r /usr/share/doc/fzf/examples/key-bindings.zsh ]] && source /usr/share/doc/fzf/examples/key-bindings.zsh

--- a/.fzf.zsh
+++ b/.fzf.zsh
@@ -4,10 +4,14 @@ if [[ ! "$PATH" == */opt/homebrew/opt/fzf/bin* ]]; then
   export PATH="${PATH:+${PATH}:}/opt/homebrew/opt/fzf/bin"
 fi
 
-# Auto-completion
-# ---------------
-[[ $- == *i* ]] && source "/opt/homebrew/opt/fzf/shell/completion.zsh" 2> /dev/null
-
-# Key bindings
-# ------------
-source "/opt/homebrew/opt/fzf/shell/key-bindings.zsh"
+# Auto-completion + key bindings — try Homebrew (macOS) then Debian/Ubuntu paths.
+for _fzf_base in \
+  /opt/homebrew/opt/fzf/shell \
+  /usr/share/doc/fzf/examples; do
+  if [[ -r "$_fzf_base/key-bindings.zsh" ]]; then
+    [[ $- == *i* ]] && source "$_fzf_base/completion.zsh" 2>/dev/null
+    source "$_fzf_base/key-bindings.zsh"
+    break
+  fi
+done
+unset _fzf_base

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !.config/nvim/
 !.config/mise/
 !.config/ghostty/
+.config/mise/config.local.toml
 .config/nvim/lazy-lock.json
 channel.xml
 bin/oversee*

--- a/.zshrc
+++ b/.zshrc
@@ -15,11 +15,8 @@ source "$HOME/.zsh/abbreviations.zsh"
 source "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
 source "$HOME/.zsh/fzf.zsh"
 source "$HOME/.zsh/auto-notify.plugin.zsh"
-for _za in /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh \
-           /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh; do
-  [[ -f "$_za" ]] && { source "$_za"; break; }
-done
-unset _za
+[[ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+[[ -f /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 
 # Inlcude a private/local zshrc for ENV secrets and customizations
 [[ -f "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"

--- a/.zshrc
+++ b/.zshrc
@@ -15,7 +15,11 @@ source "$HOME/.zsh/abbreviations.zsh"
 source "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
 source "$HOME/.zsh/fzf.zsh"
 source "$HOME/.zsh/auto-notify.plugin.zsh"
-source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+for _za in /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh \
+           /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh; do
+  [[ -f "$_za" ]] && { source "$_za"; break; }
+done
+unset _za
 
 # Inlcude a private/local zshrc for ENV secrets and customizations
 [[ -f "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"
@@ -28,7 +32,7 @@ opsi() {
 }
 
 mfa() {
-  source ~/Code/department-of-veterans-affairs/devops/utilities/issue_mfa.sh Eric.Boehs $1
+  source ~/Code/github.com/department-of-veterans-affairs/devops/utilities/issue_mfa.sh Eric.Boehs $1
   sed -i '' '/export AWS_/d' ~/.zshrc.local
   env | grep AWS_ | sed -e 's/^/export /' >> ~/.zshrc.local
 }
@@ -62,9 +66,11 @@ alias weelog='cd /Users/ericboehs/.local/share/weechat/logs && rg'
 # Search oddball slack emojis
 alias ose='ranger ~/Code/oddballteam/slack-emojis/'
 
-export PATH="/opt/homebrew/opt/libxml2/bin:$PATH"
-export PATH="/Users/ericboehs/Code/ggerganov/whisper.cpp:$PATH"
-export OPENSSL_DIR="$(brew --prefix openssl)"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  export PATH="/opt/homebrew/opt/libxml2/bin:$PATH"
+  export PATH="/Users/ericboehs/Code/ggerganov/whisper.cpp:$PATH"
+  export OPENSSL_DIR="$(brew --prefix openssl)"
+fi
 
 # Zoxide (cd replacement)
 # Only initialize in interactive shells to avoid issues with Claude Code
@@ -72,6 +78,8 @@ export OPENSSL_DIR="$(brew --prefix openssl)"
 
 eval "$(starship init zsh)"
 eval "$(mise activate zsh)"
+# DISABLED: fnox activate causes infinite fork bomb via mise shim recursion (jdx/fnox#TBD)
+# eval "$(fnox activate zsh)"
 
 # Added by LM Studio CLI (lms)
 export PATH="$PATH:/Users/ericboehs/.cache/lm-studio/bin"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -147,9 +147,13 @@ mkdir -p ~/.config/mise
 ln -fs $PWD/.config/mise/config.toml ~/.config/mise/config.toml
 
 # Trust the symlinked mise config so activations don't error on every shell.
-if command -v mise >/dev/null; then
+# PATH may not yet include ~/.local/bin during bootstrap, so fall back to the
+# absolute path mise.run installs to.
+MISE_BIN="$(command -v mise || true)"
+[ -z "$MISE_BIN" ] && [ -x "$HOME/.local/bin/mise" ] && MISE_BIN="$HOME/.local/bin/mise"
+if [ -x "$MISE_BIN" ]; then
   echo "-----> Trusting mise config"
-  mise trust ~/.config/mise/config.toml >/dev/null
+  "$MISE_BIN" trust ~/.config/mise/config.toml >/dev/null
 fi
 
 # Install TPM (Tmux Plugin Manager) and plugins

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,10 +3,15 @@
 
 set -e # Exit on any error
 
-# Checkout dotfiles repo and cd (pushd) to it
-mkdir -p ~/Code/ericboehs/
-[[ -e ~/Code/ericboehs/dotfiles ]] || git clone https://github.com/ericboehs/dotfiles ~/Code/ericboehs/dotfiles
-pushd ~/Code/ericboehs/dotfiles > /dev/null
+# Resolve the repo location: if this script lives in a git checkout, use it;
+# otherwise (curl-install case) clone into ~/Code/github.com/ericboehs/dotfiles.
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [[ ! -d "$DOTFILES_DIR/.git" ]]; then
+  DOTFILES_DIR="$HOME/Code/github.com/ericboehs/dotfiles"
+  mkdir -p "$(dirname "$DOTFILES_DIR")"
+  [[ -e "$DOTFILES_DIR" ]] || git clone https://github.com/ericboehs/dotfiles "$DOTFILES_DIR"
+fi
+pushd "$DOTFILES_DIR" > /dev/null
 mkdir -p ~/.ssh
 
 # Make sure we're on the latest master and have the correct submodule versions
@@ -87,7 +92,7 @@ fi
 dotfiles="$(ls -a) .ssh/config"
 for f in $dotfiles; do
   overwrite=false
-  source_file=~/Code/ericboehs/dotfiles/$f
+  source_file="$DOTFILES_DIR/$f"
   target_file=~/$(dirname $f)/$(basename $f)
 
   # Skip these files
@@ -117,7 +122,7 @@ for f in $dotfiles; do
   fi
 
   if [ -e ~/$f ]; then
-    test $(readlink $source_file) = $(readlink ~/Code/ericboehs/dotfiles/$f) && continue
+    test $(readlink $source_file) = $(readlink "$DOTFILES_DIR/$f") && continue
 
     if [ "$FORCE_OVERWRITE" == "true" ]; then
       overwrite=true
@@ -141,10 +146,10 @@ done
 # Symlink .config directories
 mkdir -p ~/.config
 echo "-----> Linking neovim config"
-ln -fns $PWD/.config/nvim ~/.config/nvim
+ln -fns "$DOTFILES_DIR/.config"/nvim ~/.config/nvim
 echo "-----> Linking mise config"
 mkdir -p ~/.config/mise
-ln -fs $PWD/.config/mise/config.toml ~/.config/mise/config.toml
+ln -fs "$DOTFILES_DIR/.config"/mise/config.toml ~/.config/mise/config.toml
 
 # Trust the symlinked mise config so activations don't error on every shell.
 # PATH may not yet include ~/.local/bin during bootstrap, so fall back to the

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Installation script adopted from https://gist.github.com/sonots/4239842
 
 set -e # Exit on any error
@@ -57,6 +57,30 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   else
     echo "-----> Catppuccin Mocha color scheme already imported"
   fi
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  echo "-----> Installing Linux dependencies via apt"
+  # apt packages: equivalents to the brew list on macOS.
+  # fd is fd-find (binary: fdfind), bat is bat (binary: batcat) — we create
+  # ~/.local/bin shims further down.
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+    zsh neovim direnv lsd starship zoxide fzf zsh-autosuggestions \
+    gnupg tmux ripgrep fd-find bat lua5.4 gh git-delta
+
+  echo "-----> Installing mise"
+  if ! command -v mise >/dev/null; then
+    curl -fsSL https://mise.run | sh
+  fi
+
+  echo "-----> Linking ~/.local/bin shims for fd and bat"
+  mkdir -p "$HOME/.local/bin"
+  [ -x /usr/bin/fdfind ]  && ln -sf /usr/bin/fdfind  "$HOME/.local/bin/fd"
+  [ -x /usr/bin/batcat ]  && ln -sf /usr/bin/batcat  "$HOME/.local/bin/bat"
+
+  echo "-----> Setting zsh as the default shell"
+  if [ "$SHELL" != "$(command -v zsh)" ]; then
+    sudo chsh -s "$(command -v zsh)" "$USER"
+  fi
 fi
 
 # symlink all dotfiles into ~ (skip if they exist)
@@ -73,6 +97,7 @@ for f in $dotfiles; do
   [ $f = ".git" ]         && continue
   [ $f = ".gitignore" ]   && continue
   [ $f = ".gitmodules" ]  && continue
+  [ $f = ".config" ]      && continue
   [ $f = "bootstrap.sh" ] && continue
   [ $f = "README.md" ]    && continue
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Installation script adopted from https://gist.github.com/sonots/4239842
 
-set -e # Exit on any error
+set -eo pipefail # Exit on any error; catch failures in piped commands (curl | sh)
 
 # Resolve the repo location: if this script lives in a git checkout, use it;
 # otherwise (curl-install case) clone into ~/Code/github.com/ericboehs/dotfiles.
@@ -122,7 +122,7 @@ for f in $dotfiles; do
   fi
 
   if [ -e ~/$f ]; then
-    test $(readlink $source_file) = $(readlink "$DOTFILES_DIR/$f") && continue
+    [ "$(readlink "$HOME/$f")" = "$DOTFILES_DIR/$f" ] && continue
 
     if [ "$FORCE_OVERWRITE" == "true" ]; then
       overwrite=true

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -146,6 +146,12 @@ echo "-----> Linking mise config"
 mkdir -p ~/.config/mise
 ln -fs $PWD/.config/mise/config.toml ~/.config/mise/config.toml
 
+# Trust the symlinked mise config so activations don't error on every shell.
+if command -v mise >/dev/null; then
+  echo "-----> Trusting mise config"
+  mise trust ~/.config/mise/config.toml >/dev/null
+fi
+
 # Install TPM (Tmux Plugin Manager) and plugins
 if [ ! -d ~/.tmux/plugins/tpm ]; then
   echo "-----> Installing TPM (Tmux Plugin Manager)"


### PR DESCRIPTION
## Summary
- Teaches `bootstrap.sh` to provision Debian/Ubuntu hosts (specifically Raspberry Pi OS Trixie on arm64) with the same toolchain as macOS.
- Guards Homebrew-only `.zshrc` paths behind `$OSTYPE == darwin*` so a fresh Linux login doesn't spew `brew: command not found`.
- Makes `.fzf.zsh` and the `zsh-autosuggestions` source line fall through Homebrew **and** Debian paths.
- Teaches `bootstrap.sh` to `mise trust` the symlinked config (otherwise every shell load errors).

## Why
I'm spinning up Raspberry Pi 4Bs as headless Claude Code agents (see [ericboehs/pi-agents](https://github.com/ericboehs/pi-agents)). Having the same dotfiles on those Pis makes context-switching between Mac and Pi frictionless.

## Key changes
- **bootstrap.sh**
  - `#!/usr/bin/env bash` (was `#!/bin/sh` — `[[`/`pushd` need bash; breaks under dash on Debian).
  - New `elif [[ "$OSTYPE" == "linux-gnu"* ]]` branch: apt-installs the equivalents of the macOS brew list, installs mise via the official `https://mise.run` script, shims `fd`→`fdfind` and `bat`→`batcat` in `~/.local/bin`, and `chsh`s to zsh.
  - `.config` added to the generic symlink loop's skip list — the explicit nvim/mise links below are the source of truth; the loop's `ln -fs` with a directory target was creating nested symlinks.
  - After the explicit mise config link, `mise trust ~/.config/mise/config.toml` (fall back to `~/.local/bin/mise` when PATH doesn't have it yet).
- **.zshrc**
  - Homebrew PATH entries + `OPENSSL_DIR="$(brew --prefix openssl)"` now wrapped in an `OSTYPE` check.
  - `zsh-autosuggestions` source: loops over Homebrew and Debian paths, sources the first one found.
- **.fzf.zsh**
  - Same treatment — auto-detect `/opt/homebrew/opt/fzf/shell` vs `/usr/share/doc/fzf/examples`.

## Test plan
- [x] Fresh `ssh agent@agent-1.local` to a Pi 4B on Pi OS Trixie: `curl -sL https://raw.github.com/ericboehs/dotfiles/linux-support/bootstrap.sh | FORCE_OVERWRITE=true bash` completes with exit 0.
- [x] All tools resolve in an interactive zsh: `nvim tmux rg fd bat lsd starship zoxide fzf delta gh mise` all found.
- [x] `fzf-cd-widget` is defined (fzf key bindings source cleanly).
- [x] `mise --version` prints without the "not trusted" error.
- [x] `getent passwd agent | cut -d: -f7` is `/usr/bin/zsh`.
- [ ] Sanity check that nothing regressed on macOS (re-run `FORCE_OVERWRITE=true bash ~/Code/ericboehs/dotfiles/bootstrap.sh` on your Mac).